### PR TITLE
Warning when primary x col is empty

### DIFF
--- a/R/GaussSuppression.R
+++ b/R/GaussSuppression.R
@@ -129,9 +129,10 @@ GaussSuppression <- function(x, candidates = 1:ncol(x), primary = NULL, forced =
     gaussSuppression1 <- GaussSuppression1(x, candidates, primary, printInc, singleton = singleton, nForced = nForced, singletonMethod = singletonMethod, tolGauss=tolGauss, ...)
     
     if(length(gaussSuppression1) & !is.null(whenEmptyUnsuppressed)){
-      earlyUnsuppressed <- candidates[(!(candidates %in% gaussSuppression1)) & (candidates < max(gaussSuppression1))]
-      if(length(earlyUnsuppressed)){
-        if(min(colSums(abs(x[, earlyUnsuppressed, drop = FALSE]))) == 0){
+      lateUnsuppressed <- candidates[SeqInc(1L + min(match(gaussSuppression1, candidates)), length(candidates))]
+      lateUnsuppressed <- lateUnsuppressed[!(lateUnsuppressed %in% gaussSuppression1)]
+      if(length(lateUnsuppressed)){
+        if(min(colSums(abs(x[, lateUnsuppressed, drop = FALSE]))) == 0){
           whenEmptyUnsuppressed("Cells with empty input will never be secondary suppressed. Extend input data with zeros?")
         }
       }

--- a/R/GaussSuppression.R
+++ b/R/GaussSuppression.R
@@ -29,8 +29,8 @@
 #' @param singletonMethod Method for handling the problem of singletons and zeros: `"anySum"` (default), `"anySumNOTprimary"`, `"subSum"`, `"subSpace"` or `"none"` (see details).
 #' @param printInc Printing "..." to console when TRUE
 #' @param tolGauss A tolerance parameter for sparse Gaussian elimination and linear dependency. This parameter is used only in cases where integer calculation cannot be used.
-#' @param whenEmptySuppressed Function to be called when empty input to primary suppressed cells is problematic.
-#' @param whenEmptyUnsuppressed Function to be called when empty input to candidate cells may be problematic. 
+#' @param whenEmptySuppressed Function to be called when empty input to primary suppressed cells is problematic. Supply NULL to do nothing.
+#' @param whenEmptyUnsuppressed Function to be called when empty input to candidate cells may be problematic. Supply NULL to do nothing.
 #' @param ... Extra unused parameters
 #'
 #' @return Secondary suppression indices  
@@ -120,13 +120,15 @@ GaussSuppression <- function(x, candidates = 1:ncol(x), primary = NULL, forced =
   
   if (singletonMethod %in% c("subSum", "subSpace", "anySum", "anySumNOTprimary", "subSumSpace", "subSumAny", "none")) {
     
-    if(min(colSums(abs(x[, primary, drop = FALSE]))) == 0){
-      whenEmptySuppressed("Suppressed cells with empty input will not be protected. Extend input data with zeros?")
+    if(!is.null(whenEmptySuppressed)){
+      if(min(colSums(abs(x[, primary, drop = FALSE]))) == 0){
+        whenEmptySuppressed("Suppressed cells with empty input will not be protected. Extend input data with zeros?")
+      }
     }
     
     gaussSuppression1 <- GaussSuppression1(x, candidates, primary, printInc, singleton = singleton, nForced = nForced, singletonMethod = singletonMethod, tolGauss=tolGauss, ...)
     
-    if(length(gaussSuppression1)){
+    if(length(gaussSuppression1) & !is.null(whenEmptyUnsuppressed)){
       earlyUnsuppressed <- candidates[(!(candidates %in% gaussSuppression1)) & (candidates < max(gaussSuppression1))]
       if(length(earlyUnsuppressed)){
         if(min(colSums(abs(x[, earlyUnsuppressed, drop = FALSE]))) == 0){

--- a/R/GaussSuppression.R
+++ b/R/GaussSuppression.R
@@ -29,6 +29,7 @@
 #' @param singletonMethod Method for handling the problem of singletons and zeros: `"anySum"` (default), `"anySumNOTprimary"`, `"subSum"`, `"subSpace"` or `"none"` (see details).
 #' @param printInc Printing "..." to console when TRUE
 #' @param tolGauss A tolerance parameter for sparse Gaussian elimination and linear dependency. This parameter is used only in cases where integer calculation cannot be used.
+#' @param whenEmptySuppressed Function to be called when empty input is problematic. 
 #' @param ... Extra unused parameters
 #'
 #' @return Secondary suppression indices  
@@ -68,6 +69,7 @@
 #' 
 GaussSuppression <- function(x, candidates = 1:ncol(x), primary = NULL, forced = NULL, hidden = NULL, 
                              singleton = rep(FALSE, NROW(x)), singletonMethod = "anySum", printInc = TRUE, tolGauss = (.Machine$double.eps)^(1/2),
+                             whenEmptySuppressed = warning, 
                              ...) {
   if (is.logical(primary)) 
     primary <- which(primary) 
@@ -117,7 +119,7 @@ GaussSuppression <- function(x, candidates = 1:ncol(x), primary = NULL, forced =
   if (singletonMethod %in% c("subSum", "subSpace", "anySum", "anySumNOTprimary", "subSumSpace", "subSumAny", "none")) {
     
     if(min(colSums(abs(x[, primary, drop = FALSE]))) == 0){
-      warning("Suppressed cells with empty input will not be protected. Extend input data with zeros?")
+      whenEmptySuppressed("Suppressed cells with empty input will not be protected. Extend input data with zeros?")
     }
     
     return(GaussSuppression1(x, candidates, primary, printInc, singleton = singleton, nForced = nForced, singletonMethod = singletonMethod, tolGauss=tolGauss, ...))

--- a/R/GaussSuppression.R
+++ b/R/GaussSuppression.R
@@ -115,6 +115,11 @@ GaussSuppression <- function(x, candidates = 1:ncol(x), primary = NULL, forced =
   }
   
   if (singletonMethod %in% c("subSum", "subSpace", "anySum", "anySumNOTprimary", "subSumSpace", "subSumAny", "none")) {
+    
+    if(min(colSums(abs(x[, primary, drop = FALSE]))) == 0){
+      warning("Suppressed cells with empty input will not be protected. Extend input data with zeros?")
+    }
+    
     return(GaussSuppression1(x, candidates, primary, printInc, singleton = singleton, nForced = nForced, singletonMethod = singletonMethod, tolGauss=tolGauss, ...))
   }
   

--- a/man/GaussSuppression.Rd
+++ b/man/GaussSuppression.Rd
@@ -39,9 +39,9 @@ Normally, this means cells with 1s when 0s are non-suppressed and cells with 0s 
 
 \item{tolGauss}{A tolerance parameter for sparse Gaussian elimination and linear dependency. This parameter is used only in cases where integer calculation cannot be used.}
 
-\item{whenEmptySuppressed}{Function to be called when empty input to primary suppressed cells is problematic.}
+\item{whenEmptySuppressed}{Function to be called when empty input to primary suppressed cells is problematic. Supply NULL to do nothing.}
 
-\item{whenEmptyUnsuppressed}{Function to be called when empty input to candidate cells may be problematic.}
+\item{whenEmptyUnsuppressed}{Function to be called when empty input to candidate cells may be problematic. Supply NULL to do nothing.}
 
 \item{...}{Extra unused parameters}
 }

--- a/man/GaussSuppression.Rd
+++ b/man/GaussSuppression.Rd
@@ -15,6 +15,7 @@ GaussSuppression(
   printInc = TRUE,
   tolGauss = (.Machine$double.eps)^(1/2),
   whenEmptySuppressed = warning,
+  whenEmptyUnsuppressed = message,
   ...
 )
 }
@@ -38,7 +39,9 @@ Normally, this means cells with 1s when 0s are non-suppressed and cells with 0s 
 
 \item{tolGauss}{A tolerance parameter for sparse Gaussian elimination and linear dependency. This parameter is used only in cases where integer calculation cannot be used.}
 
-\item{whenEmptySuppressed}{Function to be called when empty input is problematic.}
+\item{whenEmptySuppressed}{Function to be called when empty input to primary suppressed cells is problematic.}
+
+\item{whenEmptyUnsuppressed}{Function to be called when empty input to candidate cells may be problematic.}
 
 \item{...}{Extra unused parameters}
 }

--- a/man/GaussSuppression.Rd
+++ b/man/GaussSuppression.Rd
@@ -14,6 +14,7 @@ GaussSuppression(
   singletonMethod = "anySum",
   printInc = TRUE,
   tolGauss = (.Machine$double.eps)^(1/2),
+  whenEmptySuppressed = warning,
   ...
 )
 }
@@ -36,6 +37,8 @@ Normally, this means cells with 1s when 0s are non-suppressed and cells with 0s 
 \item{printInc}{Printing "..." to console when TRUE}
 
 \item{tolGauss}{A tolerance parameter for sparse Gaussian elimination and linear dependency. This parameter is used only in cases where integer calculation cannot be used.}
+
+\item{whenEmptySuppressed}{Function to be called when empty input is problematic.}
 
 \item{...}{Extra unused parameters}
 }


### PR DESCRIPTION
```
library(GaussSuppression)
z1 <- SSBtoolsData("z1")
a1 <- GaussSuppressionFromData(z1[-1,], 1:2, 3)
a2 <- GaussSuppressionFromData(z1[-1,], 1:2, 3, whenEmptySuppressed=NULL)
a3 <- GaussSuppressionFromData(z1[-1,], 1:2, 3, whenEmptySuppressed=stop)
a4 <- GaussSuppressionFromData(z1[-1,], 1:2, 3, protectZeros = FALSE, secondaryZeros = TRUE,whenEmptyUnsuppressed=warning)
```