### PR TITLE
Fix in `table_all_integers()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SSBtools
 Type: Package
 Title: Algorithms and Tools for Tabular Statistics and Hierarchical Computations
-Version: 1.8.6
-Date: 2025-12-01
+Version: 1.8.7
+Date: 2026-05-12
 Authors@R: c(person("Øyvind", "Langsrud", role = c("aut", "cre"),
                     email = "oyl@ssb.no",
                     comment = c(ORCID = "0000-0002-1380-4396")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,9 +18,9 @@ License: MIT + file LICENSE
 URL: https://github.com/statisticsnorway/ssb-ssbtools, https://statisticsnorway.github.io/ssb-ssbtools/
 BugReports: https://github.com/statisticsnorway/ssb-ssbtools/issues
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 Encoding: UTF-8
 Suggests: 
     testthat, 
     data.table,
     bit64
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+
+## SSBtools 1.8.7
+* Fix in `table_all_integers()`
+  - Avoid base R `factor()` bug causing every 100,000th table count to be incorrectly set to 0.
+  - See [GaussSuppression issue #155](https://github.com/statisticsnorway/ssb-gausssuppression/issues/155)
+
 ## SSBtools 1.8.6
 * Added support for named total vectors in `ModelMatrix()` and related functions.
   - `FormulaSums()`/`Formula2ModelMatrix()` can now accept multiple total codes

--- a/R/table_all_integers.R
+++ b/R/table_all_integers.R
@@ -11,5 +11,5 @@
 #' table_all_integers(c(2, 3, 5, 3, 5, 3), 7)
 #' 
 table_all_integers <- function(x, n) {
-  table(factor(x, levels = seq_len(n)))
+  table(factor(as.integer(x), levels = seq_len(n)))
 }

--- a/man/convert_integer64.Rd
+++ b/man/convert_integer64.Rd
@@ -107,5 +107,5 @@ if (requireNamespace("bit64", quietly = TRUE)) {
 
 }
 \seealso{
-\code{\link[bit64:as.integer64.character]{bit64::as.integer64()}}
+\code{\link[bit64:as.integer64]{bit64::as.integer64()}}
 }


### PR DESCRIPTION
  - Avoid base R `factor()` bug causing every 100,000th table count to be incorrectly set to 0.
  - See [GaussSuppression issue #155](https://github.com/statisticsnorway/ssb-gausssuppression/issues/155)